### PR TITLE
Updated d3 event references to fix Firefox compatibility issues

### DIFF
--- a/chapter-3/example-5.html
+++ b/chapter-3/example-5.html
@@ -48,7 +48,7 @@ var rectangles = function(svg) {
   rect.enter().append('rect')
     .attr('test', function(d,i) {
       // Enter called 2 times only
-      console.log('enter placing inital rectangle: ', i)
+      console.log('enter placing initial rectangle: ', i)
   });
 
   // Update

--- a/chapter-5/example-1.html
+++ b/chapter-5/example-1.html
@@ -46,10 +46,10 @@
   var mexico = void 0;
 
   var hover = function(d) {
-    console.log('d', d, 'event', event);
+    console.log('d', d, 'event', d3.event);
     var div = document.getElementById('tooltip');
-    div.style.left = event.pageX +'px';
-    div.style.top = event.pageY + 'px';
+    div.style.left = d3.event.pageX +'px';
+    div.style.top = d3.event.pageY + 'px';
     div.innerHTML = d.properties.NAME_1;
   };
 

--- a/chapter-5/example-2.html
+++ b/chapter-5/example-2.html
@@ -69,8 +69,8 @@
 
   var hover = function(d) {
     var div = document.getElementById('tooltip');
-    div.style.left = event.pageX +'px';
-    div.style.top = event.pageY + 'px';
+    div.style.left = d3.event.pageX +'px';
+    div.style.top = d3.event.pageY + 'px';
     div.innerHTML = d.properties.NAME_1;
 
     var id = geoID(d);


### PR DESCRIPTION
The event references don't work in Firefox but they do work if you call them as d3.event so I updated this in the examples that weren't functioning.  Verified that the examples now work in both Chrome and Firefox.

Also fixed a typo in a console.log output.
